### PR TITLE
feat(chat): add pagination and infinite scroll to chat messages

### DIFF
--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { createSocketConnection } from "../utils/socket";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import useChat from "../hooks/useChat";
+import axios from "axios";
+import { BASE_URL } from "../utils/constants";
 
 const Chat = () => {
   const { receiverId } = useParams();
@@ -11,10 +13,52 @@ const Chat = () => {
   const [chatMsg, setChatMsg] = useState([]);
   const [newMessage, setNewMessage] = useState("");
   const messagesEndRef = useRef(null);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const messagesContainerRef = useRef(null);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
+  const loadMessages = useCallback(
+    async (pageNum) => {
+      try {
+        setLoading(true);
+        const limit = 2;
+        const { data } = await axios.get(
+          BASE_URL + `/chat/${receiverId}?page=${pageNum}&limit=${limit}`,
+          {
+            withCredentials: true,
+          }
+        );
+
+        const chatMessages = data?.messages.map((msg) => {
+          const { sender, message } = msg;
+          return {
+            firstName: sender?.firstName,
+            lastName: sender?.lastName,
+            photoUrl: sender?.photoUrl,
+            createdAt: sender?.createdAt,
+            message,
+          };
+        });
+
+        console.log("chatMessages:", chatMessages);
+        setChatMsg((prev) => [...chatMessages, ...prev]);
+        setTotalPages(data.totalPages);
+        setLoading(false);
+      } catch (error) {
+        setLoading(false);
+        throw new Error(error);
+      }
+    },
+    [receiverId]
+  );
+
+  useEffect(() => {
+    loadMessages(1);
+  }, [receiverId]);
 
   useEffect(() => {
     getChat(setChatMsg);
@@ -49,6 +93,36 @@ const Chat = () => {
     };
   }, [userData]);
 
+  // Handle scroll events for infinite loading
+  useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      if (container.scrollTop === 0 && !loading && page < totalPages) {
+        // At top of container and more pages to load
+        setPage((prev) => {
+          const newPage = prev + 1;
+          loadMessages(newPage);
+          return newPage;
+        });
+      } else if (
+        container.scrollToBottom === 0 &&
+        !loading &&
+        page < totalPages
+      ) {
+        setPage((prev) => {
+          const newPage = prev + 1;
+          loadMessages(newPage);
+          return newPage;
+        });
+      }
+    };
+
+    container.addEventListener("scroll", handleScroll);
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [loading, page, totalPages, loadMessages]);
+
   const sendMessage = () => {
     const socket = createSocketConnection();
     socket.emit("sendMessage", {
@@ -67,7 +141,13 @@ const Chat = () => {
       <div className="border-b border-b-teal-400 py-2 px-3">
         <h2 className="text-xl">Chat</h2>
       </div>
-      <div className="h-full overflow-y-auto">
+      <div className="h-full overflow-y-auto" ref={messagesContainerRef}>
+        {loading && page > 1 && (
+          <div className="flex justify-center py-2">
+            <div className="loading loading-spinner text-primary"></div>
+          </div>
+        )}
+
         {chatMsg?.map((msg, index) => (
           <div
             className={`chat ${

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -2,11 +2,14 @@ import { BASE_URL } from "../utils/constants";
 import axios from "axios";
 
 const useChat = (receiverId) => {
-  const getChat = async (setChatMsg) => {
+  const getChat = async (page = 1) => {
     try {
-      const { data } = await axios.get(BASE_URL + `/chat/${receiverId}`, {
-        withCredentials: true,
-      });
+      const { data } = await axios.get(
+        BASE_URL + `/chat/${receiverId}?page=${page}`,
+        {
+          withCredentials: true,
+        }
+      );
 
       const chatMessages = data?.messages.map((msg) => {
         const { sender, message } = msg;
@@ -18,7 +21,12 @@ const useChat = (receiverId) => {
           message,
         };
       });
-      setChatMsg(chatMessages);
+      return {
+        messages: chatMessages,
+        totalPages: data.totalPages,
+        currentPage: data.currentPage,
+      };
+      // setChatMsg(chatMessages);
     } catch (error) {
       throw new Error(error);
     }


### PR DESCRIPTION
Implement pagination for chat messages to improve performance by loading messages in chunks. Add infinite scroll functionality to load older messages as the user scrolls up. This reduces initial load time and enhances user experience by avoiding overwhelming the UI with all messages at once.